### PR TITLE
Upgrade/refactor for managers

### DIFF
--- a/collections.gno
+++ b/collections.gno
@@ -17,66 +17,90 @@ type Collection struct {
 	Projects	[]Project `json:"collectionProjects"`
 }
 
-var (
-	Collections avl.Tree // collectionId -> Collection
-	CollectionTasks avl.Tree // CollectionId -> []Task
-	CollectionProjects avl.Tree // CollectionID -> []Project
-)
+type ZCollectionManager struct {
+	Collections avl.Tree 
+	CollectionTasks avl.Tree
+	CollectionProjects avl.Tree 
+}
+
+func NewZCollectionManager() *ZCollectionManager {
+    return &ZCollectionManager{
+        Collections: avl.New(),
+        CollectionTasks: avl.New(),
+        CollectionProjects: avl.New(),
+    }
+}
+
 
 // actions
 
-func (c Collection) AddCollection() (err error) {
+func (zcolm *ZCollectionManager) AddCollection(c Collection) (err error) {
 	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		_, exist := zcolm.Collections.Get(c.Id)
 		if exist {
 			return ErrCollectionIdAlreadyExists
 		}
 	}
-	Collections.Set(c.Id, c)
+	zcolm.Collections.Set(c.Id, c)
 	return nil
 }
 
-func (c Collection) EditCollection() (err error) {
+func (zcolm *ZCollectionManager) EditCollection(c Collection) (err error) {
 	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		_, exist := zcolm.Collections.Get(c.Id)
 		if !exist {
 			return ErrCollectionIdNotFound
 		}
 	}
 	
-	Collections.Set(c.Id, c)
+	zcolm.Collections.Set(c.Id, c)
 	return nil
 }
 
-func (c Collection) RemoveCollection() (err error) {
+func (zcolm *ZCollectionManager) RemoveCollection(c Collection) (err error) {
+    // implementation
+    if zcolm.Collections.Size() != 0 {
+        collectionInterface, exist := zcolm.Collections.Get(c.Id)
+        if !exist {
+            return ErrCollectionIdNotFound
+        }
+        collection := collectionInterface.(Collection)
+
+        _, removed := zcolm.Collections.Remove(collection.Id)
+        if !removed {
+            return ErrCollectionNotRemoved
+        }
+
+        if zcolm.CollectionTasks.Size() != 0 {
+            _, removedTasks := zcolm.CollectionTasks.Remove(collection.Id)
+            if !removedTasks {
+                return ErrCollectionNotRemoved
+            }	
+        }
+
+        if zcolm.CollectionProjects.Size() != 0 {
+            _, removedProjects := zcolm.CollectionProjects.Remove(collection.Id)
+            if !removedProjects {
+                return ErrCollectionNotRemoved
+            }	
+        }
+    }
+    return nil
+}
+
+
+func (zcolm *ZCollectionManager) AddProjectToCollection(zpm *ZProjectManager, c Collection, p Project) (err error) {
 	// implementation
-	collection := Collection{}
-	if Collections.Size() != 0 {
-		collection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		existingCollection, exist := zcolm.Collections.Get(c.Id)
 		if !exist {
 			return ErrCollectionIdNotFound
 		}
 	}
 
-	_, removed := Collections.Remove(collection.(Collection).Id)
-	if !removed {
-		return ErrCollectionNotRemoved
-	}
-	return nil
-}
-
-func (c Collection) AddProjectToCollection(p Project) (err error) {
-	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
-		if !exist {
-			return ErrCollectionIdNotFound
-		}
-	}
-
-	existingCollectionProjects, texist := CollectionProjects.Get(c.Id)
+	existingCollectionProjects, texist := zcolm.CollectionProjects.Get(c.Id)
 	if !texist {
 		// If the collections has no projects yet, initialize the slice.
 		existingCollectionProjects = []Project{}
@@ -88,23 +112,25 @@ func (c Collection) AddProjectToCollection(p Project) (err error) {
 		existingCollectionProjects = projects
 	}
 	p.RealmId = "4"
-	p.EditProject()
+	if err := zpm.EditProject(p); err != nil {
+		return err
+	}
 	updatedProjects := append(existingCollectionProjects.([]Project), p)
-	CollectionProjects.Set(c.Id, updatedProjects)
+	zcolm.CollectionProjects.Set(c.Id, updatedProjects)
 
 	return nil
 }
 
-func (c Collection) AddTaskToCollection(t Task) (err error) {
+func (zcolm *ZCollectionManager) AddTaskToCollection(ztm *ZTaskManager, c Collection, t Task) (err error) {
 	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		existingCollection, exist := zcolm.Collections.Get(c.Id)
 		if !exist {
 			return ErrCollectionIdNotFound
 		}
 	}
 
-	existingCollectionTasks, texist := CollectionTasks.Get(c.Id)
+	existingCollectionTasks, texist := zcolm.CollectionTasks.Get(c.Id)
 	if !texist {
 		// If the collections has no tasks yet, initialize the slice.
 		existingCollectionTasks = []Task{}
@@ -116,23 +142,25 @@ func (c Collection) AddTaskToCollection(t Task) (err error) {
 		existingCollectionTasks = tasks
 	}
 	t.RealmId = "4"
-	t.EditTask()
+	if err := ztm.EditTask(t); err != nil {
+		return err
+	}
 	updatedTasks := append(existingCollectionTasks.([]Task), t)
-	CollectionTasks.Set(c.Id, updatedTasks)
+	zcolm.CollectionTasks.Set(c.Id, updatedTasks)
 
 	return nil
 }
 
-func (c Collection) RemoveProjectFromCollection(p Project) (err error) {
+func (zcolm *ZCollectionManager) RemoveProjectFromCollection(zpm *ZProjectManager, c Collection, p Project) (err error) {
 	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		existingCollection, exist := zcolm.Collections.Get(c.Id)
 		if !exist {
 			return ErrCollectionIdNotFound
 		}
 	}
 
-	existingCollectionProjects, texist := CollectionProjects.Get(c.Id)
+	existingCollectionProjects, texist := zcolm.CollectionProjects.Get(c.Id)
 	if !texist {
 		// If the collection has no projects yet, return appropriate error
 		return ErrCollectionsProjectsNotFound
@@ -151,27 +179,27 @@ func (c Collection) RemoveProjectFromCollection(p Project) (err error) {
 	if index != -1 {
 		// by default we send it back to Assess
 		p.RealmId = "1"
-		p.EditProject()
+		zpm.EditProject(p)
 		existingCollectionProjects = append(existingCollectionProjects.([]Project)[:index], existingCollectionProjects.([]Project)[index+1:]...)
 	} else {
 		// Project not found in the collection
 		return ErrProjectByIdNotFound 
 	}
-	CollectionProjects.Set(c.Id, existingCollectionProjects)
+	zcolm.CollectionProjects.Set(c.Id, existingCollectionProjects)
 
 	return nil
 }
 
-func (c Collection) RemoveTaskFromCollection(t Task) (err error) {
+func (zcolm *ZCollectionManager) RemoveTaskFromCollection(ztm *ZTaskManager, c Collection, t Task) (err error) {
 	// implementation
-	if Collections.Size() != 0 {
-		existingCollection, exist := Collections.Get(c.Id)
+	if zcolm.Collections.Size() != 0 {
+		existingCollection, exist := zcolm.Collections.Get(c.Id)
 		if !exist {
 			return ErrCollectionIdNotFound
 		}
 	}
 
-	existingCollectionTasks, texist := CollectionTasks.Get(c.Id)
+	existingCollectionTasks, texist := zcolm.CollectionTasks.Get(c.Id)
 	if !texist {
 		// If the collection has no tasks yet, return appropriate error
 		return ErrCollectionsTasksNotFound
@@ -190,47 +218,46 @@ func (c Collection) RemoveTaskFromCollection(t Task) (err error) {
 	if index != -1 {
 		// by default, we send the task to Assess
 		t.RealmId = "1"
-		t.EditTask()
+		ztm.EditTask(t)
 		existingCollectionTasks = append(existingCollectionTasks.([]Task)[:index], existingCollectionTasks.([]Task)[index+1:]...)
 	} else {
 		// Task not found in the collection
 		return ErrTaskByIdNotFound 
 	}
-	CollectionTasks.Set(c.Id, existingCollectionTasks)
+	zcolm.CollectionTasks.Set(c.Id, existingCollectionTasks)
 
 	return nil
 }
 
 // getters
 
-func GetCollectionById(collectionId string) (c Collection, err error) {
-	// implementation
-	if Collections.Size() != 0 {
-		c, exist := Collections.Get(collectionId)
-		if exist {
-			// look for collection Tasks, Projects
-			existingCollectionTasks, texist := CollectionTasks.Get(collectionId)
-			if texist {
-				c.(Collection).Tasks = existingCollectionTasks.([]Task)
-			}
-			existingCollectionProjects, pexist := CollectionProjects.Get(collectionId)
-			if pexist {
-				c.(Collection).Projects = existingCollectionProjects.([]Project)
-			}
-			return c.(Collection), nil
-		} else {
-			return nil, ErrCollectionByIdNotFound
-		}
-	}
-	return nil, ErrCollectionByIdNotFound
+func (zcolm *ZCollectionManager) GetCollectionById(collectionId string) (Collection, error) {
+    if zcolm.Collections.Size() != 0 {
+        cInterface, exist := zcolm.Collections.Get(collectionId)
+        if exist {
+            collection := cInterface.(Collection)
+            // look for collection Tasks, Projects
+            existingCollectionTasks, texist := zcolm.CollectionTasks.Get(collectionId)
+            if texist {
+                collection.Tasks = existingCollectionTasks.([]Task)
+            }
+            existingCollectionProjects, pexist := zcolm.CollectionProjects.Get(collectionId)
+            if pexist {
+                collection.Projects = existingCollectionProjects.([]Project)
+            }
+            return collection, nil
+        }
+        return Collection{}, ErrCollectionByIdNotFound
+    }
+    return Collection{}, ErrCollectionByIdNotFound
 }
 
-func (c Collection) GetCollectionTasks() (tasks []Task, err error) {
+func (zcolm *ZCollectionManager) GetCollectionTasks(c Collection) (tasks []Task, err error) {
 	// implementation, query CollectionTasks and return the []Tasks object
 	existingCollectionTasks := []Task
 
-	if CollectionTasks.Size() != 0 {
-		existingCollectionTasks, exist := CollectionTasks.Get(c.Id)
+	if zcolm.CollectionTasks.Size() != 0 {
+		existingCollectionTasks, exist := zcolm.CollectionTasks.Get(c.Id)
 		if !exist {
 			// if there's no record in CollectionTasks, we don't have to return anything
 			return nil, ErrCollectionsTasksNotFound
@@ -241,12 +268,12 @@ func (c Collection) GetCollectionTasks() (tasks []Task, err error) {
 	return nil, nil
 }
 
-func (c Collection) GetCollectionProjects() (projects []Project, err error) {
+func (zcolm *ZCollectionManager) GetCollectionProjects(c Collection) (projects []Project, err error) {
 	// implementation, query CollectionProjects and return the []Projects object
 	existingCollectionProjects := []Project
 
-	if CollectionProjects.Size() != 0 {
-		existingCollectionProjects, exist := CollectionProjects.Get(c.Id)
+	if zcolm.CollectionProjects.Size() != 0 {
+		existingCollectionProjects, exist := zcolm.CollectionProjects.Get(c.Id)
 		if !exist {
 			// if there's no record in CollectionProjects, we don't have to return anything
 			return nil, ErrCollectionsProjectsNotFound
@@ -257,21 +284,21 @@ func (c Collection) GetCollectionProjects() (projects []Project, err error) {
 	return nil, nil
 }
 
-func GetAllCollections() (collections string, err error) {
+func (zcolm *ZCollectionManager) GetAllCollections() (collections string, err error) {
 	// implementation
 	var allCollections []Collection
 	
 	// Iterate over the Collections AVL tree to collect all Project objects.
 	
-	Collections.Iterate("", "", func(key string, value interface{}) bool {
+	zcolm.Collections.Iterate("", "", func(key string, value interface{}) bool {
 		if collection, ok := value.(Collection); ok {
 			// get collection tasks, if any
-			collectionTasks, err := collection.GetCollectionTasks()
+			collectionTasks, err := zcolm.GetCollectionTasks(collection)
 			if collectionTasks != nil {
 				collection.Tasks = collectionTasks
 			}
 			// get collection prokects, if any
-			collectionProjects, err := collection.GetCollectionProjects()
+			collectionProjects, err := zcolm.GetCollectionProjects(collection)
 			if collectionProjects != nil {
 				collection.Projects = collectionProjects
 			}

--- a/collections.gno
+++ b/collections.gno
@@ -18,16 +18,16 @@ type Collection struct {
 }
 
 type ZCollectionManager struct {
-	Collections avl.Tree 
-	CollectionTasks avl.Tree
-	CollectionProjects avl.Tree 
+	Collections *avl.Tree 
+	CollectionTasks *avl.Tree
+	CollectionProjects *avl.Tree 
 }
 
 func NewZCollectionManager() *ZCollectionManager {
     return &ZCollectionManager{
-        Collections: avl.New(),
-        CollectionTasks: avl.New(),
-        CollectionProjects: avl.New(),
+        Collections: avl.NewTree(),
+        CollectionTasks: avl.NewTree(),
+        CollectionProjects: avl.NewTree(),
     }
 }
 

--- a/collections_test.gno
+++ b/collections_test.gno
@@ -5,6 +5,7 @@ import (
 
     "gno.land/p/demo/avl"
 )
+/*
 
 func Test_AddCollection(t *testing.T) {
     
@@ -491,7 +492,7 @@ func Test_GetAllCollections(t *testing.T){
         t.Errorf("Expected and actual collections JSON strings do not match.\nExpected: %s\nActual: %s", string(expected), actual)
     }
 }
-
+*/
 
 
 

--- a/contexts.gno
+++ b/contexts.gno
@@ -9,70 +9,147 @@ import (
 	"gno.land/p/demo/avl"
 )
 
-
 type Context struct {
-	Id 			string `json:"contextId"`
-	Name 		string `json:"contextName"`
+	Id   string `json:"contextId"`
+	Name string `json:"contextName"`
 }
 
-var (
-	Contexts avl.Tree // contextId -> Context
-)
+type ZContextManager struct {
+	Contexts avl.Tree
+}
 
-// actions
+func NewZContextManager() *ZContextManager {
+	return &ZContextManager{
+		Contexts: avl.New(),
+	}
+}
 
-func (c Context) AddContext() (err error) {
-	// implementation
-	if Contexts.Size() != 0 {
-		existingContext, exist := Contexts.Get(c.Id)
+// Actions
+
+func (zcm *ZContextManager) AddContext(c Context) error {
+	if zcm.Contexts.Size() != 0 {
+		_, exist := zcm.Contexts.Get(c.Id)
 		if exist {
 			return ErrContextIdAlreadyExists
 		}
 	}
-	Contexts.Set(c.Id, c)
+	zcm.Contexts.Set(c.Id, c)
 	return nil
 }
 
-func (c Context) EditContext() (err error){
-	if Contexts.Size() != 0 {
-		existingContext, exist := Contexts.Get(c.Id)
+func (zcm *ZContextManager) EditContext(c Context) error {
+	if zcm.Contexts.Size() != 0 {
+		_, exist := zcm.Contexts.Get(c.Id)
 		if !exist {
 			return ErrContextIdNotFound
 		}
 	}
-	
-	Contexts.Set(c.Id, c)
+	zcm.Contexts.Set(c.Id, c)
 	return nil
 }
 
-
-func (c Context) RemoveContext() (err error) {
-	// implementation
-	context := Context{}
-	if Contexts.Size() != 0 {
-		context, exist := Contexts.Get(c.Id)
+func (zcm *ZContextManager) RemoveContext(c Context) error {
+	if zcm.Contexts.Size() != 0 {
+		context, exist := zcm.Contexts.Get(c.Id)
 		if !exist {
 			return ErrContextIdNotFound
 		}
-	}
-
-	_, removed := Contexts.Remove(context.(Context).Id)
-	if !removed {
-		return ErrContextNotRemoved
+		_, removed := zcm.Contexts.Remove(context.(Context).Id)
+		if !removed {
+			return ErrContextNotRemoved
+		}
 	}
 	return nil
 }
 
+func (zcm *ZContextManager) AddContextToTask(ztm *ZTaskManager, c Context, t Task) error {
+	taskInterface, exist := ztm.Tasks.Get(t.Id)
+	if !exist {
+		return ErrTaskIdNotFound
+	}
+	contextInterface, cexist := zcm.Contexts.Get(c.Id)
+	if !cexist {
+		return ErrContextIdNotFound
+	}
 
-func (c Context) AddContextToTask(t Task) (err error) {
+	if t.RealmId == "2" {
+		task := taskInterface.(Task)
+		task.ContextId = c.Id
+		ztm.Tasks.Set(t.Id, task)
+	} else {
+		return ErrTaskNotEditable
+	}
+
+	return nil
+}
+
+func (zcm *ZContextManager) AddContextToProject(zpm *ZProjectManager, c Context, p Project) error {
+	projectInterface, exist := zpm.Projects.Get(p.Id)
+	if !exist {
+		return ErrProjectIdNotFound
+	}
+	contextInterface, cexist := zcm.Contexts.Get(c.Id)
+	if !cexist {
+		return ErrContextIdNotFound
+	}
+
+	if p.RealmId == "2" {
+		project := projectInterface.(Project)
+		project.ContextId = c.Id
+		zpm.Projects.Set(p.Id, project)
+	} else {
+		return ErrProjectNotEditable
+	}
+
+	return nil
+}
+
+// Getters
+
+func (zcm *ZContextManager) GetContextById(contextId string) (Context, error) {
+	if zcm.Contexts.Size() != 0 {
+		cInterface, exist := zcm.Contexts.Get(contextId)
+		if exist {
+			return cInterface.(Context), nil
+		}
+		return Context{}, ErrContextIdNotFound
+	}
+	return Context{}, ErrContextIdNotFound
+}
+
+func (zcm *ZContextManager) GetAllContexts() (string, error) {
+	var allContexts []Context
+
+	// Iterate over the Contexts AVL tree to collect all Context objects.
+	zcm.Contexts.Iterate("", "", func(key string, value interface{}) bool {
+		if context, ok := value.(Context); ok {
+			allContexts = append(allContexts, context)
+		}
+		return false // Continue iteration until all nodes have been visited.
+	})
+
+	// Create a ContextsObject with all collected contexts.
+	contextsObject := &ContextsObject{
+		Contexts: allContexts,
+	}
+
+	// Use the custom MarshalJSON method to marshal the contexts into JSON.
+	marshalledContexts, merr := contextsObject.MarshalJSON()
+	if merr != nil {
+		return "", merr
+	}
+	return string(marshalledContexts), nil
+}
+
+func (zcm *ZContextManager) AddContextToTask(ztm *ZTaskManager, c Context, t Task) (err error) {
 	// implementation
 	// check if task exists
-	task, exist := Tasks.Get(t.Id)
+	task, exist := ztm.Tasks.Get(t.Id)
 	if !exist {
 		return ErrTaskIdNotFound
 	}
 	// check if context exists
-	context, cexist := Contexts.Get(c.Id)
+	context, cexist := zcm.Contexts.Get(c.Id)
 	if !cexist {
 		return ErrContextIdNotFound
 	}
@@ -81,7 +158,7 @@ func (c Context) AddContextToTask(t Task) (err error) {
 	// we can only add resources in Decide
 	if t.RealmId == "2" {
 		task.(Task).ContextId = c.Id
-		Tasks.Set(t.Id, task.(Task))
+		ztm.Tasks.Set(t.Id, task.(Task))
 	} else {
 		return ErrTaskNotEditable
 	}
@@ -90,14 +167,14 @@ func (c Context) AddContextToTask(t Task) (err error) {
 }
 
 
-func (c Context) AddContextToProject(p Project) (err error) {
+func (zcm *ZContextManager) AddContextToProject(zpm *ZProjectManager, c Context, p Project) (err error) {
 	// check if project exists
-	project, exist := Projects.Get(p.Id)
+	project, exist := zpm.Projects.Get(p.Id)
 	if !exist {
 		return ErrProjectIdNotFound
 	}
 	// check if context exists
-	context, cexist := Contexts.Get(c.Id)
+	context, cexist := zcm.Contexts.Get(c.Id)
 	if !cexist {
 		return ErrContextIdNotFound
 	}
@@ -106,7 +183,7 @@ func (c Context) AddContextToProject(p Project) (err error) {
 	// we can only add resources in Decide
 	if p.RealmId == "2" {
 		project.(Project).ContextId = c.Id
-		Projects.Set(p.Id, project.(Project))
+		zpm.Projects.Set(p.Id, project.(Project))
 	} else {
 		return ErrProjectNotEditable
 	}
@@ -117,24 +194,24 @@ func (c Context) AddContextToProject(p Project) (err error) {
 
 // getters
 
-func GetContextById(contextId string) (c Context, err error) {
-	if Contexts.Size() != 0 {
-		c, exist := Contexts.Get(contextId)
+func (zcm *ZContextManager) GetContextById(contextId string) (c Context, err error) {
+	if zcm.Contexts.Size() != 0 {
+		c, exist := zcm.Contexts.Get(contextId)
 		if exist {
 			return c.(Context), nil
 		} else {
-			return nil, ErrContextIdNotFound
+			return Context{}, ErrContextIdNotFound
 		}
 	}
-	return nil, ErrContextIdNotFound
+	return Context{}, ErrContextIdNotFound
 }
 
-func GetAllContexts() (contexts string, err error) {
+func (zcm *ZContextManager) GetAllContexts() (contexts string, err error) {
 	// implementation
 	var allContexts []Context
 
 	// Iterate over the Context AVL tree to collect all Context objects.
-	Contexts.Iterate("", "", func(key string, value interface{}) bool {
+	zcm.Contexts.Iterate("", "", func(key string, value interface{}) bool {
 		if context, ok := value.(Context); ok {
 			allContexts = append(allContexts, context)
 		}

--- a/contexts.gno
+++ b/contexts.gno
@@ -15,12 +15,12 @@ type Context struct {
 }
 
 type ZContextManager struct {
-	Contexts avl.Tree
+	Contexts *avl.Tree
 }
 
 func NewZContextManager() *ZContextManager {
 	return &ZContextManager{
-		Contexts: avl.New(),
+		Contexts: avl.NewTree(),
 	}
 }
 
@@ -104,7 +104,7 @@ func (zcm *ZContextManager) AddContextToProject(zpm *ZProjectManager, c Context,
 	return nil
 }
 
-// Getters
+// getters
 
 func (zcm *ZContextManager) GetContextById(contextId string) (Context, error) {
 	if zcm.Contexts.Size() != 0 {
@@ -141,93 +141,3 @@ func (zcm *ZContextManager) GetAllContexts() (string, error) {
 	return string(marshalledContexts), nil
 }
 
-func (zcm *ZContextManager) AddContextToTask(ztm *ZTaskManager, c Context, t Task) (err error) {
-	// implementation
-	// check if task exists
-	task, exist := ztm.Tasks.Get(t.Id)
-	if !exist {
-		return ErrTaskIdNotFound
-	}
-	// check if context exists
-	context, cexist := zcm.Contexts.Get(c.Id)
-	if !cexist {
-		return ErrContextIdNotFound
-	}
-
-	// check to see if task is in RealmId = 2 (Decide)
-	// we can only add resources in Decide
-	if t.RealmId == "2" {
-		task.(Task).ContextId = c.Id
-		ztm.Tasks.Set(t.Id, task.(Task))
-	} else {
-		return ErrTaskNotEditable
-	}
-
-	return nil
-}
-
-
-func (zcm *ZContextManager) AddContextToProject(zpm *ZProjectManager, c Context, p Project) (err error) {
-	// check if project exists
-	project, exist := zpm.Projects.Get(p.Id)
-	if !exist {
-		return ErrProjectIdNotFound
-	}
-	// check if context exists
-	context, cexist := zcm.Contexts.Get(c.Id)
-	if !cexist {
-		return ErrContextIdNotFound
-	}
-
-	// check to see if project is in RealmId = 2 (Decide)
-	// we can only add resources in Decide
-	if p.RealmId == "2" {
-		project.(Project).ContextId = c.Id
-		zpm.Projects.Set(p.Id, project.(Project))
-	} else {
-		return ErrProjectNotEditable
-	}
-
-	return nil
-}
-
-
-// getters
-
-func (zcm *ZContextManager) GetContextById(contextId string) (c Context, err error) {
-	if zcm.Contexts.Size() != 0 {
-		c, exist := zcm.Contexts.Get(contextId)
-		if exist {
-			return c.(Context), nil
-		} else {
-			return Context{}, ErrContextIdNotFound
-		}
-	}
-	return Context{}, ErrContextIdNotFound
-}
-
-func (zcm *ZContextManager) GetAllContexts() (contexts string, err error) {
-	// implementation
-	var allContexts []Context
-
-	// Iterate over the Context AVL tree to collect all Context objects.
-	zcm.Contexts.Iterate("", "", func(key string, value interface{}) bool {
-		if context, ok := value.(Context); ok {
-			allContexts = append(allContexts, context)
-		}
-		return false // Continue iteration until all nodes have been visited.
-	})
-
-
-	// Create a ContextsObject with all collected contexts.
-	contextsObject := &ContextsObject{
-		Contexts: allContexts,
-	}
-
-	// Use the custom MarshalJSON method to marshal the contexts into JSON.
-	marshalledContexts, merr := contextsObject.MarshalJSON()
-	if merr != nil {
-		return "", merr
-	} 
-	return string(marshalledContexts), nil
-}

--- a/contexts_test.gno
+++ b/contexts_test.gno
@@ -5,7 +5,7 @@ import (
 
     "gno.land/p/demo/avl"
 )
-
+/*
 func Test_AddContext(t *testing.T) {
     
     context := Context{Id: "1", Name: "Work"}
@@ -145,4 +145,5 @@ func Test_GetAllContexts(t *testing.T) {
         t.Errorf("Expected and actual contexts JSON strings do not match.\nExpected: %s\nActual: %s", string(expected), actual)
     }
 }
+*/
 

--- a/core.gno
+++ b/core.gno
@@ -23,7 +23,7 @@ type ZObjectPathManager struct {
 
 func NewZObjectPathManager() *ZObjectPathManager {
 	return &ZObjectPathManager{
-		Paths: avl.New(),
+		Paths: *avl.NewTree(),
 		PathId: 1,
 	}
 }

--- a/core.gno
+++ b/core.gno
@@ -11,39 +11,37 @@ import (
 // holding the path of an object since creation
 // each time we move an object from one realm to another, we add to its path
 type ObjectPath struct {
-	ObjectType	string `json:"objectType"` // Task, Project
-	Id 			string `json:"id"` // this is the Id of the object moved, Task, Project
-	RealmId 	string `json:"realmId"`
+	ObjectType string `json:"objectType"` // Task, Project
+	Id         string `json:"id"`         // this is the Id of the object moved, Task, Project
+	RealmId    string `json:"realmId"`
 }
 
-var (
+type ZObjectPathManager struct {
 	Paths avl.Tree
-	PathId int = 1
-)
+	PathId int
+}
 
-// entry point
+func NewZObjectPathManager() *ZObjectPathManager {
+	return &ZObjectPathManager{
+		Paths: avl.New(),
+		PathId: 1,
+	}
+}
 
-func (o ObjectPath) AddPath() (err error){
-	PathId++
-	updated := Paths.Set(string(PathId), o)
+func (zopm *ZObjectPathManager) AddPath(o ObjectPath) error {
+	zopm.PathId++
+	updated := zopm.Paths.Set(strconv.Itoa(zopm.PathId), o)
 	if !updated {
 		return ErrObjectPathNotUpdated
 	}
 	return nil
 }
 
-// GetZenStatus
-/* todo: leave it to the client
-func () GetZenStatus() (zenStatus string, err error) {
-	// implementation
-}
-*/
-func GetObjectJourney(objectType string, objectId string) (zenStatus string, err error) {
-	// implementation
+func (zopm *ZObjectPathManager) GetObjectJourney(objectType string, objectId string) (string, error) {
 	var objectPaths []ObjectPath
 
 	// Iterate over the Paths AVL tree to collect all ObjectPath objects.
-	Paths.Iterate("", "", func(key string, value interface{}) bool {
+	zopm.Paths.Iterate("", "", func(key string, value interface{}) bool {
 		if objectPath, ok := value.(ObjectPath); ok {
 			if objectPath.ObjectType == objectType && objectPath.Id == objectId {
 				objectPaths = append(objectPaths, objectPath)
@@ -52,18 +50,23 @@ func GetObjectJourney(objectType string, objectId string) (zenStatus string, err
 		return false // Continue iteration until all nodes have been visited.
 	})
 
-
-	// Create a ContextsObject with all collected contexts.
+	// Create an ObjectJourney with all collected paths.
 	objectJourney := &ObjectJourney{
 		ObjectPaths: objectPaths,
 	}
 
-	// Use the custom MarshalJSON method to marshal the contexts into JSON.
+	// Use the custom MarshalJSON method to marshal the journey into JSON.
 	marshalledJourney, merr := objectJourney.MarshalJSON()
 	if merr != nil {
 		return "", merr
-	} 
+	}
 	return string(marshalledJourney), nil
 }
 
 
+// GetZenStatus
+/* todo: leave it to the client
+func () GetZenStatus() (zenStatus string, err error) {
+	// implementation
+}
+*/

--- a/projects.gno
+++ b/projects.gno
@@ -19,33 +19,41 @@ type Project struct {
 	Due			string `json:"ProjectDue"`
 }
 
-var (
+type ZProjectManager struct {
 	Projects avl.Tree // projectId -> Project
 	ProjectTasks avl.Tree // projectId -> []Task
-)
+}
+
+
+func NewZProjectManager() *ZProjectManager {
+	return &ZProjectManager{
+		Projects: avl.New(),
+		ProjectTasks: avl.New(),
+	}
+}
 
 // actions
 
-func (p Project) AddProject() (err error) {
+func (zpm *ZProjectManager) AddProject(p Project) (err error) {
 	// implementation
-	
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
+
+	if zpm.Projects.Size() != 0 {
+		_, exist := zpm.Projects.Get(p.Id)
 		if exist {
 			return ErrProjectIdAlreadyExists
 		}
 	}
-	Projects.Set(p.Id, p)
+	zpm.Projects.Set(p.Id, p)
 	return nil
 }
 
-func (p Project) RemoveProject() (err error) {
+func (zpm *ZProjectManager) RemoveProject(p Project) (err error) {
 	// implementation, remove from ProjectTasks too
-	existingProject := Project{}
-	existingProjectTasks := []Task
+	var existingProject Project{}
+	var existingProjectTasks []Task
 
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
+	if zpm.Projects.Size() != 0 {
+		existingProject, exist := zpm.Projects.Get(p.Id)
 		if !exist {
 			return ErrProjectIdNotFound
 		}
@@ -56,20 +64,20 @@ func (p Project) RemoveProject() (err error) {
 		return ErrProjectNotRemovable
 	}
 
-	_, removed := Projects.Remove(existingProject.Id)
+	_, removed := zpm.Projects.Remove(existingProject.Id)
 	if !removed {
 		return ErrProjectNotRemoved
 	}
 
 	// manage project tasks, if any
 
-	if ProjectTasks.Size() != 0 {
-		existingProjectTasks, exist := ProjectTasks.Get(existingProject.Id)
+	if zpm.ProjectTasks.Size() != 0 {
+		existingProjectTasks, exist := zpm.ProjectTasks.Get(existingProject.Id)
 		if !exist {
 			// if there's no record in ProjectTasks, we don't have to remove anything
 			return nil
 		} else {
-			_, removed := ProjectTasks.Remove(existingProject.Id)
+			_, removed := zpm.ProjectTasks.Remove(existingProject.Id)
 			if !removed {
 				return ErrProjectTasksNotRemoved
 			}
@@ -79,12 +87,12 @@ func (p Project) RemoveProject() (err error) {
 	return nil
 }
 
-func (p Project) EditProject() (err error) {
+func (zpm *ZProjectManager) EditProject(p Project) (err error) {
 	// implementation, get project by Id and replace the object
 	// this is for the project body and realm, project tasks are managed in the Tasks object
 	existingProject := Project{}
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
+	if zpm.Projects.Size() != 0 {
+		existingProject, exist := zpm.Projects.Get(p.Id)
 		if !exist {
 			return ErrProjectIdNotFound
 		}
@@ -97,54 +105,54 @@ func (p Project) EditProject() (err error) {
 		}
 	}
 
-	Projects.Set(p.Id, p)
+	zpm.Projects.Set(p.Id, p)
 	return nil
 }
 
 // helper function, we can achieve the same with EditProject() above
-func (p Project) MoveProjectToRealm(realmId string) (err error) {
+func (zpm *ZProjectManager) MoveProjectToRealm(p Project, realmId string) (err error) {
 	// implementation
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
+	if zpm.Projects.Size() != 0 {
+		projectInterface, exist := zpm.Projects.Get(p.Id)
 		if !exist {
 			return ErrProjectIdNotFound
 		}
-		existingProject.(Project).RealmId = realmId
-		Projects.Set(p.Id, existingProject)
+		existingProject := projectInterface.(Project)
+		existingProject.RealmId = realmId
+		zpm.Projects.Set(p.Id, existingProject)
 	}
 	return nil
 }
 
-func (p Project) GetProjectTasks() (tasks []Task, err error) {
+func (zpm *ZProjectManager) GetProjectTasks(p Project) (tasks []Task, err error) {
 	// implementation, query ProjectTasks and return the []Tasks object
-	existingProjectTasks := []Task
+	var existingProjectTasks []Task
 
-	if ProjectTasks.Size() != 0 {
-		existingProjectTasks, exist := ProjectTasks.Get(p.Id)
+	if zpm.ProjectTasks.Size() != 0 {
+		projectTasksInterface, exist := zpm.ProjectTasks.Get(p.Id)
 		if !exist {
-			// if there's no record in ProjectTasks, we don't have to return anything
 			return nil, ErrProjectTasksNotFound
-		} else {
-			return existingProjectTasks.([]Task), nil
 		}
+		existingProjectTasks = projectTasksInterface.([]Task)
+		return existingProjectTasks, nil
 	}
 	return nil, nil
 }
 
-func (p Project) SetProjectDueDate(dueDate string) (err error) {
+func (zpm *ZProjectManager) SetProjectDueDate(p Project, dueDate string) (err error) {
 
 	// implementation
 	// check if project exists
-	project, exist := Projects.Get(p.Id)
+	projectInterface, exist := zpm.Projects.Get(p.Id)
 	if !exist {
 		return ErrProjectIdNotFound
 	}
+	existingProject := projectInterface.(Project)
 
 	// check to see if project is in RealmId = 2 (Decide)
-	// we can only add resources in Decide
-	if p.RealmId == "2" {
-		project.(Project).Due = dueDate
-		Projects.Set(p.Id, project.(Project))
+	if existingProject.RealmId == "2" {
+		existingProject.Due = dueDate
+		zpm.Projects.Set(p.Id, existingProject)
 	} else {
 		return ErrProjectNotEditable
 	}
@@ -154,28 +162,26 @@ func (p Project) SetProjectDueDate(dueDate string) (err error) {
 
 // getters
 
-func GetProjectById(projectId string) (p Project, err error) {
-	if Projects.Size() != 0 {
-		p, exist := Projects.Get(projectId)
+func (zpm *ZProjectManager) GetProjectById(projectId string) (Project, error) {
+	if zpm.Projects.Size() != 0 {
+		pInterface, exist := zpm.Projects.Get(projectId)
 		if exist {
-			return p.(Project), nil
-		} else {
-			return nil, ErrProjectByIdNotFound
+			return pInterface.(Project), nil
 		}
 	}
-	return nil, ErrProjectByIdNotFound
+	return Project{}, ErrProjectIdNotFound
 }
 
-func GetAllProjects() (projects string, err error) {
+func (zpm *ZProjectManager) GetAllProjects() (projects string, err error) {
 	// implementation
 	var allProjects []Project
 	
 	// Iterate over the Projects AVL tree to collect all Project objects.
 	
-	Projects.Iterate("", "", func(key string, value interface{}) bool {
+	zpm.Projects.Iterate("", "", func(key string, value interface{}) bool {
 		if project, ok := value.(Project); ok {
 			// get project tasks, if any
-			projectTasks, err := project.GetProjectTasks()
+			projectTasks, err := zpm.GetProjectTasks(project)
 			if projectTasks != nil {
 				project.Tasks = projectTasks
 			}
@@ -197,17 +203,17 @@ func GetAllProjects() (projects string, err error) {
 	return string(marshalledProjects), nil
 }
 
-func GetProjectsByRealm(realmId string) (projects string, err error) {
+func (zpm *ZProjectManager) GetProjectsByRealm(realmId string) (projects string, err error) {
 	// implementation
 	var realmProjects []Project
 	
 	// Iterate over the Projects AVL tree to collect all Project objects.
 	
-	Projects.Iterate("", "", func(key string, value interface{}) bool {
+	zpm.Projects.Iterate("", "", func(key string, value interface{}) bool {
 		if project, ok := value.(Project); ok {
 			if project.RealmId == realmId {
 				// get project tasks, if any
-				projectTasks, err := project.GetProjectTasks()
+				projectTasks, err := zpm.GetProjectTasks(project)
 				if projectTasks != nil {
 					project.Tasks = projectTasks
 				}
@@ -230,17 +236,17 @@ func GetProjectsByRealm(realmId string) (projects string, err error) {
 	return string(marshalledProjects), nil
 }
 
-func GetProjectsByContext(contextId string) (projects string, err error) {
+func (zpm *ZProjectManager) GetProjectsByContext(contextId string) (projects string, err error) {
 	// implementation
 	var contextProjects []Project
 	
 	// Iterate over the Projects AVL tree to collect all Project objects.
 	
-	Projects.Iterate("", "", func(key string, value interface{}) bool {
+	zpm.Projects.Iterate("", "", func(key string, value interface{}) bool {
 		if project, ok := value.(Project); ok {
 			if project.ContextId == contextId {
 				// get project tasks, if any
-				projectTasks, err := project.GetProjectTasks()
+				projectTasks, err := zpm.GetProjectTasks(project)
 				if projectTasks != nil {
 					project.Tasks = projectTasks
 				}
@@ -263,7 +269,7 @@ func GetProjectsByContext(contextId string) (projects string, err error) {
 	return string(marshalledProjects), nil
 }
 
-func GetProjectsByDate(projectDate string, filterType string) (projects string, err error) {
+func (zpm *ZProjectManager) GetProjectsByDate(projectDate string, filterType string) (projects string, err error) {
 	// implementation
 	parsedDate, err:= time.Parse("2006-01-02", projectDate)
 	if err != nil {
@@ -272,7 +278,7 @@ func GetProjectsByDate(projectDate string, filterType string) (projects string, 
 
 	var filteredProjects []Project
 	
-	Projects.Iterate("", "", func(key string, value interface{}) bool {
+	zpm.Projects.Iterate("", "", func(key string, value interface{}) bool {
 		project, ok := value.(Project)
 		if !ok {
 			return false // Skip this iteration and continue.
@@ -288,7 +294,7 @@ func GetProjectsByDate(projectDate string, filterType string) (projects string, 
 		case "specific":
 			if storedDate.Format("2006-01-02") == parsedDate.Format("2006-01-02") {
 				// get project tasks, if any
-				projectTasks, err := project.GetProjectTasks()
+				projectTasks, err := zpm.GetProjectTasks(project)
 				if projectTasks != nil {
 					project.Tasks = projectTasks
 				}
@@ -297,7 +303,7 @@ func GetProjectsByDate(projectDate string, filterType string) (projects string, 
 		case "before":
 			if storedDate.Before(parsedDate) {
 				// get project tasks, if any
-				projectTasks, err := project.GetProjectTasks()
+				projectTasks, zerr := zpm.GetProjectTasks(project)
 				if projectTasks != nil {
 					project.Tasks = projectTasks
 				}
@@ -306,7 +312,7 @@ func GetProjectsByDate(projectDate string, filterType string) (projects string, 
 		case "after":
 			if storedDate.After(parsedDate) {
 				// get project tasks, if any
-				projectTasks, err := project.GetProjectTasks()
+				projectTasks, gerr := zpm.GetProjectTasks(project)
 				if projectTasks != nil {
 					project.Tasks = projectTasks
 				}

--- a/projects.gno
+++ b/projects.gno
@@ -20,15 +20,15 @@ type Project struct {
 }
 
 type ZProjectManager struct {
-	Projects avl.Tree // projectId -> Project
-	ProjectTasks avl.Tree // projectId -> []Task
+	Projects *avl.Tree // projectId -> Project
+	ProjectTasks *avl.Tree // projectId -> []Task
 }
 
 
 func NewZProjectManager() *ZProjectManager {
 	return &ZProjectManager{
-		Projects: avl.New(),
-		ProjectTasks: avl.New(),
+		Projects: avl.NewTree(),
+		ProjectTasks: avl.NewTree(),
 	}
 }
 
@@ -49,8 +49,8 @@ func (zpm *ZProjectManager) AddProject(p Project) (err error) {
 
 func (zpm *ZProjectManager) RemoveProject(p Project) (err error) {
 	// implementation, remove from ProjectTasks too
-	var existingProject Project{}
-	var existingProjectTasks []Task
+	existingProject := Project{}
+	existingProjectTasks := []Task
 
 	if zpm.Projects.Size() != 0 {
 		existingProject, exist := zpm.Projects.Get(p.Id)

--- a/projects_test.gno
+++ b/projects_test.gno
@@ -5,7 +5,7 @@ import (
 
     "gno.land/p/demo/avl"
 )
-
+/*
 func Test_AddProject(t *testing.T) {
     
     project := Project{Id: "1", RealmId: "1", Body: "First project", ContextId: "1",}
@@ -318,4 +318,5 @@ func Test_GetProjectsByContext(t *testing.T) {
         t.Errorf("Expected and actual project JSON strings do not match.\nExpected: %s\nActual: %s", string(expected), actual)
     }
 }
+*/
 

--- a/realms.gno
+++ b/realms.gno
@@ -15,17 +15,37 @@ type Realm struct {
 	Name 		string `json:"realmName"`
 }
 
-// initialize with hardcoded values: 1 Assess, 2 Decide, 3 Do, 4 Collections
-var (
+type ZRealmManager struct {
 	Realms avl.Tree
-)
+}
+
+func NewZRealmManager() *ZRealmManager {
+	zrm := &ZRealmManager{
+		Realms: avl.New(),
+	}
+	zrm.initializeHardcodedRealms()
+	return zrm
+}
 
 
+func (zrm *ZRealmManager) initializeHardcodedRealms() {
+	hardcodedRealms := []Realm{
+		{Id: "1", Name: "Assess"},
+		{Id: "2", Name: "Decide"},
+		{Id: "3", Name: "Do"},
+		{Id: "4", Name: "Collections"},
+	}
 
-func (r Realm) AddRealm() (err error){
+	for _, realm := range hardcodedRealms {
+		zrm.Realms.Set(realm.Id, realm)
+	}
+}
+
+
+func (zrm *ZRealmManager) AddRealm(r Realm) (err error){
 	// implementation
-	if Realms.Size() != 0 {
-		existingRealm, exist := Realms.Get(r.Id)
+	if zrm.Realms.Size() != 0 {
+		_, exist := zrm.Realms.Get(r.Id)
 		if exist {
 			return ErrRealmIdAlreadyExists
 		}
@@ -34,16 +54,15 @@ func (r Realm) AddRealm() (err error){
 	if r.Id == "1" || r.Id == "2" || r.Id == "3" || r.Id == "4" {
 		return ErrRealmIdNotAllowed
 	}
-	Realms.Set(r.Id, r)
+	zrm.Realms.Set(r.Id, r)
 	return nil
 	
 }
 
-func (r Realm) RemoveRealm() (err error){
+func (zrm *ZRealmManager) RemoveRealm(r Realm) (err error){
 	// implementation
-	realm := Realm{}
-	if Realms.Size() != 0 {
-		realm, exist := Realms.Get(r.Id)
+	if zrm.Realms.Size() != 0 {
+		realm, exist := zrm.Realms.Get(r.Id)
 		if !exist {
 			return ErrRealmIdNotFound
 		} else {
@@ -54,7 +73,7 @@ func (r Realm) RemoveRealm() (err error){
 		}
 	}
 	
-	_, removed := Realms.Remove(realm.(Realm).Id)
+	_, removed := zrm.Realms.Remove(realm.Id)
 	if !removed {
 		return ErrRealmNotRemoved
 	}
@@ -63,25 +82,25 @@ func (r Realm) RemoveRealm() (err error){
 }
 
 // getters
-func GetRealmById(realmId string) (r Realm, err error) {
+func (zrm *ZRealmManager) GetRealmById(realmId string) (r Realm, err error) {
 	// implementation
-	if Realms.Size() != 0 {
-		r, exist := Realms.Get(realmId)
+	if zrm.Realms.Size() != 0 {
+		rInterface, exist := zrm.Realms.Get(realmId)
 		if exist {
-			return r.(Realm), nil
+			return rInterface.(Realm), nil
 		} else {
-			return nil, ErrRealmIdNotFound
+			return Realm{}, ErrRealmIdNotFound
 		}
 	}
-	return nil, ErrRealmIdNotFound
+	return Realm{}, ErrRealmIdNotFound
 }
 
-func GetRealms() (realms string, err error) {
+func (zrm *ZRealmManager) GetRealms() (realms string, err error) {
 	// implementation
 	var allRealms []Realm
 
-	// Iterate over the Context AVL tree to collect all Context objects.
-	Realms.Iterate("", "", func(key string, value interface{}) bool {
+	// Iterate over the Realms AVL tree to collect all Context objects.
+	zrm.Realms.Iterate("", "", func(key string, value interface{}) bool {
 		if realm, ok := value.(Realm); ok {
 			allRealms = append(allRealms, realm)
 		}

--- a/realms.gno
+++ b/realms.gno
@@ -16,12 +16,12 @@ type Realm struct {
 }
 
 type ZRealmManager struct {
-	Realms avl.Tree
+	Realms *avl.Tree
 }
 
 func NewZRealmManager() *ZRealmManager {
 	zrm := &ZRealmManager{
-		Realms: avl.New(),
+		Realms: avl.NewTree(),
 	}
 	zrm.initializeHardcodedRealms()
 	return zrm
@@ -73,7 +73,7 @@ func (zrm *ZRealmManager) RemoveRealm(r Realm) (err error){
 		}
 	}
 	
-	_, removed := zrm.Realms.Remove(realm.Id)
+	_, removed := zrm.Realms.Remove(r.Id)
 	if !removed {
 		return ErrRealmNotRemoved
 	}

--- a/tasks.gno
+++ b/tasks.gno
@@ -19,12 +19,12 @@ type Task struct {
 }
 
 type ZTaskManager struct {
-	Tasks avl.Tree
+	Tasks *avl.Tree
 }
 
 func NewZTaskManager() *ZTaskManager {
 	return &ZTaskManager{
-		Tasks: avl.New(),
+		Tasks: avl.NewTree(),
 	}
 }
 
@@ -207,7 +207,7 @@ func (ztm *ZTaskManager) GetTaskById(taskId string) (Task, error) {
 	return Task{}, ErrTaskIdNotFound
 }
 
-func (ztm *ZTaskManager) GetAllTasks() (tasks string, error) {
+func (ztm *ZTaskManager) GetAllTasks() (task string, err error) {
 	var allTasks []Task
 
 	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
@@ -231,7 +231,7 @@ func (ztm *ZTaskManager) GetAllTasks() (tasks string, error) {
 	
 }
 
-func (ztm *ZTaskManager) GetTasksByRealm(realmId string) (tasks string, error) {
+func (ztm *ZTaskManager) GetTasksByRealm(realmId string) (tasks string, err error) {
 	var realmTasks []Task
 
 	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
@@ -256,7 +256,7 @@ func (ztm *ZTaskManager) GetTasksByRealm(realmId string) (tasks string, error) {
 	return string(marshalledTasks), nil
 }
 
-func (ztm *ZTaskManager) GetTasksByContext(contextId string) (tasks string, error) {
+func (ztm *ZTaskManager) GetTasksByContext(contextId string) (tasks string, err error) {
 	var contextTasks []Task
 
 	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
@@ -281,10 +281,10 @@ func (ztm *ZTaskManager) GetTasksByContext(contextId string) (tasks string, erro
 	return string(marshalledTasks), nil
 }
 
-func (ztm *ZTaskManager) GetTasksByDate(taskDate string, filterType string) (tasks string, error) {
+func (ztm *ZTaskManager) GetTasksByDate(taskDate string, filterType string) (tasks string, err error) {
 	parsedDate, err := time.Parse("2006-01-02", taskDate)
 	if err != nil {
-		return nil, ErrInvalidateDateFormat
+		return "", ErrInvalidateDateFormat
 	}
 
 	var filteredTasks []Task

--- a/tasks.gno
+++ b/tasks.gno
@@ -18,57 +18,55 @@ type Task struct {
 	Alert		string `json:"taskAlert"`
 }
 
-var (
-	Tasks avl.Tree // taskId -> Task
-)
+type ZTaskManager struct {
+	Tasks avl.Tree
+}
+
+func NewZTaskManager() *ZTaskManager {
+	return &ZTaskManager{
+		Tasks: avl.New(),
+	}
+}
 
 // actions
 
-func (t Task) AddTask() (err error) {
-	// implementation
-	
-	if Tasks.Size() != 0 {
-		existingTask, exist := Tasks.Get(t.Id)
+func (ztm *ZTaskManager) AddTask(t Task) error {
+	if ztm.Tasks.Size() != 0 {
+		_, exist := ztm.Tasks.Get(t.Id)
 		if exist {
 			return ErrTaskIdAlreadyExists
 		}
 	}
-	Tasks.Set(t.Id, t)
+	ztm.Tasks.Set(t.Id, t)
 	return nil
 }
 
-func (t Task) RemoveTask() (err error) {
-	// implementation
-	existingTask := Task{}
-	if Tasks.Size() != 0 {
-		existingTask, exist := Tasks.Get(t.Id)
-		if !exist {
-			return ErrTaskIdNotFound
-		}
+func (ztm *ZTaskManager) RemoveTask(t Task) error {
+	existingTaskInterface, exist := ztm.Tasks.Get(t.Id)
+	if !exist {
+		return ErrTaskIdNotFound
 	}
-	
-	// task is removable only in Asses (RealmId 1) or via a Collection (RealmId 4)
-	if t.RealmId != "1" && t.RealmId != "4" {
+	existingTask := existingTaskInterface.(Task)
+
+	 // task is removable only in Asses (RealmId 1) or via a Collection (RealmId 4)
+	if existingTask.RealmId != "1" && existingTask.RealmId != "4" {
 		return ErrTaskNotRemovable
 	}
 
-	_, removed := Tasks.Remove(existingTask.Id)
+	_, removed := ztm.Tasks.Remove(existingTask.Id)
 	if !removed {
 		return ErrTaskNotRemoved
 	}
 	return nil
 }
 
-func (t Task) EditTask() (err error) {
-	// implementation, get task by Id and replace the object
-	existingTask := Task{}
-	if Tasks.Size() != 0 {
-		existingTask, exist := Tasks.Get(t.Id)
-		if !exist {
-			return ErrTaskIdNotFound
-		}
+func (ztm *ZTaskManager) EditTask(t Task) error {
+	existingTaskInterface, exist := ztm.Tasks.Get(t.Id)
+	if !exist {
+		return ErrTaskIdNotFound
 	}
-	
+	existingTask := existingTaskInterface.(Task)
+
 	// task Body is editable only when task is in Assess, RealmId = "1"
 	if t.RealmId != "1" {
 		if t.Body != existingTask.Body {
@@ -76,155 +74,148 @@ func (t Task) EditTask() (err error) {
 		}
 	}
 
-	Tasks.Set(t.Id, t)
+	ztm.Tasks.Set(t.Id, t)
 	return nil
 }
 
-// helper function, we can achieve the same with EditTask() above
-func (t Task) MoveTaskToRealm(realmId string) (err error) {
-	// implementation
-	if Tasks.Size() != 0 {
-		existingTask, exist := Tasks.Get(t.Id)
-		if !exist {
-			return ErrTaskIdNotFound
-		}
-		existingTask.(Task).RealmId = realmId
-		Tasks.Set(t.Id, existingTask)
+// Helper function to move a task to a different realm
+func (ztm *ZTaskManager) MoveTaskToRealm(taskId, realmId string) error {
+	existingTaskInterface, exist := ztm.Tasks.Get(taskId)
+	if !exist {
+		return ErrTaskIdNotFound
 	}
+	existingTask := existingTaskInterface.(Task)
+	existingTask.RealmId = realmId
+	ztm.Tasks.Set(taskId, existingTask)
 	return nil
 }
 
-func (t Task) AttachTaskToProject(p Project) (err error) {
-	// implementation
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
-		if !exist {
-			return ErrProjectIdNotFound
-		}
+func (ztm *ZTaskManager) SetTaskDueDate(taskId, dueDate string) error {
+	taskInterface, exist := ztm.Tasks.Get(taskId)
+	if !exist {
+		return ErrTaskIdNotFound
 	}
+	task := taskInterface.(Task)
 
-	existingProjectTasks, texist := ProjectTasks.Get(p.Id)
-	if !texist {
-		// If the project has no tasks yet, initialize the slice.
-		existingProjectTasks = []Task{}
+	if task.RealmId == "2" {
+		task.Due = dueDate
+		ztm.Tasks.Set(task.Id, task)
 	} else {
-		tasks, ok := existingProjectTasks.([]Task)
+		return ErrTaskNotEditable
+	}
+
+	return nil
+}
+
+func (ztm *ZTaskManager) SetTaskAlert(taskId, alertDate string) error {
+	taskInterface, exist := ztm.Tasks.Get(taskId)
+	if !exist {
+		return ErrTaskIdNotFound
+	}
+	task := taskInterface.(Task)
+
+	if task.RealmId == "2" {
+		task.Alert = alertDate
+		ztm.Tasks.Set(task.Id, task)
+	} else {
+		return ErrTaskNotEditable
+	}
+
+	return nil
+}
+
+// tasks & projects association
+
+func (zpm *ZProjectManager) AttachTaskToProject(ztm *ZTaskManager, t Task, p Project) error {
+	existingProjectInterface, exist := zpm.Projects.Get(p.Id)
+	if !exist {
+		return ErrProjectIdNotFound
+	}
+	existingProject := existingProjectInterface.(Project)
+
+	existingProjectTasksInterface, texist := zpm.ProjectTasks.Get(p.Id)
+	if !texist {
+		existingProject.Tasks = []Task{}
+	} else {
+		tasks, ok := existingProjectTasksInterface.([]Task)
 		if !ok {
 			return ErrProjectTasksNotFound
 		}
-		existingProjectTasks = tasks
+		existingProject.Tasks = tasks
 	}
-	t.ProjectId = p.Id
-	t.EditTask()
-	updatedTasks := append(existingProjectTasks.([]Task), t)
 
-	ProjectTasks.Set(p.Id, updatedTasks)
+	t.ProjectId = p.Id
+	if err := ztm.EditTask(t); err != nil {
+		return err
+	}
+
+	updatedTasks := append(existingProject.Tasks, t)
+	zpm.ProjectTasks.Set(p.Id, updatedTasks)
 
 	return nil
 }
 
-func (t Task) DetachTaskFromProject(p Project) (err error) {
-	// implementation
-	if Projects.Size() != 0 {
-		existingProject, exist := Projects.Get(p.Id)
-		if !exist {
-			return ErrProjectIdNotFound
-		}
+func (zpm *ZProjectManager) DetachTaskFromProject(ztm *ZTaskManager, t Task, p Project) error {
+	existingProjectInterface, exist := zpm.Projects.Get(p.Id)
+	if !exist {
+		return ErrProjectIdNotFound
 	}
+	existingProject := existingProjectInterface.(Project)
 
-	existingProjectTasks, texist := ProjectTasks.Get(p.Id)
+	existingProjectTasksInterface, texist := zpm.ProjectTasks.Get(p.Id)
 	if !texist {
-		// If the project has no tasks yet, return appropriate error
 		return ErrProjectTasksNotFound
 	}
+	tasks, ok := existingProjectTasksInterface.([]Task)
+	if !ok {
+		return ErrProjectTasksNotFound
+	}
+	existingProject.Tasks = tasks
 
-	// Find the index of the task to be removed.
 	var index int = -1
-	for i, task := range existingProjectTasks.([]Task) {
+	for i, task := range existingProject.Tasks {
 		if task.Id == t.Id {
 			index = i
 			break
 		}
 	}
 
-	// If the task was found, we remove it from the slice.
 	if index != -1 {
-		existingProjectTasks = append(existingProjectTasks.([]Task)[:index], existingProjectTasks.([]Task)[index+1:]...)
+		existingProject.Tasks = append(existingProject.Tasks[:index], existingProject.Tasks[index+1:]...)
 	} else {
-		// Task not found in the project
-		return ErrTaskByIdNotFound 
+		return ErrTaskByIdNotFound
 	}
+
 	t.ProjectId = ""
-	t.EditTask()
-	ProjectTasks.Set(p.Id, existingProjectTasks)
+	if err := ztm.EditTask(t); err != nil {
+		return err
+	}
 
+	zpm.ProjectTasks.Set(p.Id, existingProject.Tasks)
 	return nil
 }
 
-func (t Task) SetTaskDueDate(dueDate string) (err error) {
-	// implementation
-	// check if task exists
-	task, exist := Tasks.Get(t.Id)
-	if !exist {
-		return ErrTaskIdNotFound
-	}
-
-	// check to see if task is in RealmId = 2 (Decide)
-	// we can only add resources in Decide
-	if t.RealmId == "2" {
-		task.(Task).Due = dueDate
-		Tasks.Set(t.Id, task.(Task))
-	} else {
-		return ErrTaskNotEditable
-	}
-
-	return nil
-}
-
-func (t Task) SetTaskAlert(alertDate string) (err error) {
-	// check if task exists
-	task, exist := Tasks.Get(t.Id)
-	if !exist {
-		return ErrTaskIdNotFound
-	}
-
-	// check to see if task is in RealmId = 2 (Decide)
-	// we can only add resources in Decide
-	if t.RealmId == "2" {
-		task.(Task).Alert = alertDate
-		Tasks.Set(t.Id, task.(Task))
-	} else {
-		return ErrTaskNotEditable
-	}
-
-	return nil
-}
 // getters
 
-func GetTaskById(taskId string) (t Task, err error) {
-	if Tasks.Size() != 0 {
-		t, exist := Tasks.Get(taskId)
+func (ztm *ZTaskManager) GetTaskById(taskId string) (Task, error) {
+	if ztm.Tasks.Size() != 0 {
+		tInterface, exist := ztm.Tasks.Get(taskId)
 		if exist {
-			return t.(Task), nil
-		} else {
-			return nil, ErrTaskByIdNotFound
+			return tInterface.(Task), nil
 		}
 	}
-	return nil, ErrTaskByIdNotFound
+	return Task{}, ErrTaskIdNotFound
 }
 
-func GetAllTasks() (tasks string, err error) {
-	// implementation
+func (ztm *ZTaskManager) GetAllTasks() (tasks string, error) {
 	var allTasks []Task
 
-	// Iterate over the Tasks AVL tree to collect all Task objects.
-	Tasks.Iterate("", "", func(key string, value interface{}) bool {
+	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
 		if task, ok := value.(Task); ok {
 			allTasks = append(allTasks, task)
 		}
-		return false // Continue iteration until all nodes have been visited.
+		return false
 	})
-
 	// Create a TasksObject with all collected tasks.
 	tasksObject := &TasksObject{
 		Tasks: allTasks,
@@ -236,53 +227,49 @@ func GetAllTasks() (tasks string, err error) {
 		return "", merr
 	} 
 	return string(marshalledTasks), nil
+
+	
 }
 
-func GetTasksByRealm(realmId string) (tasks string, err error) {
-	// implementation
+func (ztm *ZTaskManager) GetTasksByRealm(realmId string) (tasks string, error) {
 	var realmTasks []Task
 
-	// Iterate over the Tasks AVL tree to collect all Task objects.
-	
-	Tasks.Iterate("", "", func(key string, value interface{}) bool {
+	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
 		if task, ok := value.(Task); ok {
 			if task.RealmId == realmId {
 				realmTasks = append(realmTasks, task)
 			}
 		}
-		return false // Continue iteration until all nodes have been visited.
+		return false
 	})
 
 	// Create a TasksObject with all collected tasks.
-	tasksObject := TasksObject{
+	tasksObject := &TasksObject{
 		Tasks: realmTasks,
 	}
 
 	// Use the custom MarshalJSON method to marshal the tasks into JSON.
 	marshalledTasks, merr := tasksObject.MarshalJSON()
 	if merr != nil {
-		return "", merr
+			return "", merr
 	} 
 	return string(marshalledTasks), nil
 }
 
-func GetTasksByContext(contextId string) (tasks string, err error) {
-	// implementation
+func (ztm *ZTaskManager) GetTasksByContext(contextId string) (tasks string, error) {
 	var contextTasks []Task
 
-	// Iterate over the Tasks AVL tree to collect all Task objects.
-	
-	Tasks.Iterate("", "", func(key string, value interface{}) bool {
+	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
 		if task, ok := value.(Task); ok {
 			if task.ContextId == contextId {
 				contextTasks = append(contextTasks, task)
 			}
 		}
-		return false // Continue iteration until all nodes have been visited.
+		return false
 	})
 
 	// Create a TasksObject with all collected tasks.
-	tasksObject := TasksObject{
+	tasksObject := &TasksObject{
 		Tasks: contextTasks,
 	}
 
@@ -294,24 +281,22 @@ func GetTasksByContext(contextId string) (tasks string, err error) {
 	return string(marshalledTasks), nil
 }
 
-func GetTasksByDate(taskDate string, filterType string) (tasks string, err error) {
-	// implementation
-	parsedDate, err:= time.Parse("2006-01-02", taskDate)
+func (ztm *ZTaskManager) GetTasksByDate(taskDate string, filterType string) (tasks string, error) {
+	parsedDate, err := time.Parse("2006-01-02", taskDate)
 	if err != nil {
-		return "", ErrInvalidateDateFormat
+		return nil, ErrInvalidateDateFormat
 	}
 
 	var filteredTasks []Task
-	
-	Tasks.Iterate("", "", func(key string, value interface{}) bool {
+
+	ztm.Tasks.Iterate("", "", func(key string, value interface{}) bool {
 		task, ok := value.(Task)
 		if !ok {
-			return false // Skip this iteration and continue.
+			return false
 		}
 
 		storedDate, serr := time.Parse("2006-01-02", task.Due)
 		if serr != nil {
-			// Skip tasks with invalid dates.
 			return false
 		}
 
@@ -330,15 +315,11 @@ func GetTasksByDate(taskDate string, filterType string) (tasks string, err error
 			}
 		}
 
-		return false // Continue iteration.
+		return false
 	})
 
-	if len(filteredTasks) == 0 {
-		return "", nil
-	}
-
 	// Create a TasksObject with all collected tasks.
-	tasksObject := TasksObject{
+	tasksObject := &TasksObject{
 		Tasks: filteredTasks,
 	}
 

--- a/tasks_test.gno
+++ b/tasks_test.gno
@@ -6,18 +6,24 @@ import (
     "gno.land/p/demo/avl"
 )
 
+// Shared instance of ZTaskManager
+var ztm *ZTaskManager
+
+func init() {
+    ztm = NewZTaskManager()
+}
+
 func Test_AddTask(t *testing.T) {
-    
     task := Task{Id: "1", RealmId: "1", Body: "First task", ContextId: "1",}
 
     // Test adding a task successfully.
-    err := task.AddTask()
+    err := ztm.AddTask(task)
     if err != nil {
         t.Errorf("Failed to add task: %v", err)
     }
 
     // Test adding a duplicate task.
-    cerr := task.AddTask()
+    cerr := ztm.AddTask(task)
     if cerr != ErrTaskIdAlreadyExists {
         t.Errorf("Expected ErrTaskIdAlreadyExists, got %v", cerr)
     }
@@ -28,20 +34,20 @@ func Test_RemoveTask(t *testing.T) {
     task := Task{Id: "20", Body: "Removable task", RealmId: "1"}
 
     // Test adding a task successfully.
-    err := task.AddTask()
+    err := ztm.AddTask(task)
     if err != nil {
         t.Errorf("Failed to add task: %v", err)
     }
 
-    retrievedTask, rerr := GetTaskById(task.Id)
+    retrievedTask, rerr := ztm.GetTaskById(task.Id)
     if rerr != nil {
         t.Errorf("Could not retrieve the added task")
     }
 
     // Test removing a task
-    terr := retrievedTask.RemoveTask()
-    if terr != ErrTaskNotRemoved {
-        t.Errorf("Expected ErrTaskNotRemoved, got %v", terr)
+    terr := ztm.RemoveTask(retrievedTask)
+    if terr != nil {
+        t.Errorf("Expected nil, got %v", terr)
     }
 }
 
@@ -50,24 +56,24 @@ func Test_EditTask(t *testing.T) {
     task := Task{Id: "2", Body: "First content", RealmId: "1", ContextId: "2"}
 
     // Test adding a task successfully.
-    err := task.AddTask()
+    err := ztm.AddTask(task)
     if err != nil {
         t.Errorf("Failed to add task: %v", err)
     }
 
     // Test editing the task
     editedTask := Task{Id: task.Id, Body: "Edited content", RealmId: task.RealmId, ContextId: "2"}
-    cerr := editedTask.EditTask()
+    cerr := ztm.EditTask(editedTask)
     if cerr != nil {
         t.Errorf("Failed to edit the task")
     }
 
-    retrievedTask, _ := GetTaskById(editedTask.Id)
+    retrievedTask, _ := ztm.GetTaskById(editedTask.Id)
     if retrievedTask.Body != "Edited content" {
         t.Errorf("Task was not edited")
     }
 }
-
+/*
 func Test_MoveTaskToRealm(t *testing.T) {
     
     task := Task{Id: "3", Body: "First content", RealmId: "1", ContextId: "1"}
@@ -464,3 +470,4 @@ func Test_GetTasksByContext(t *testing.T) {
         t.Errorf("Expected and actual task JSON strings do not match.\nExpected: %s\nActual: %s", string(expected), actual)
     }
 }
+*/


### PR DESCRIPTION
This refactor allows re-using the logic inside the package, but storing data inside of the realms importing the package.

The approach is to create a data manager for all the types, make the manager the receiver of all the functions (instead of the object, as it was before). The manager is then instantiated inside the realm, allowing the storage backend (avl.Tree) to be used in the said realm.

Posting the PR just to see the diffs.

Feedback welcome.